### PR TITLE
feat: add private mode & delete cookie

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -118,8 +118,6 @@ el.replaceWith(d);
         self.addons = addons
         self.proxy = proxy
         self.set_size = set_size
-        self.private_mode = private_mode
-        self.session_cookies_only = session_cookies_only
         # initial check
         init_ok = self._init_check()
         if not init_ok:
@@ -214,8 +212,6 @@ el.replaceWith(d);
         del self.addons
         del self.proxy
         del self.set_size
-        del self.private_mode
-        del self.session_cookies_only
 
     # Class Public Fuctions -------
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,18 +2,32 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.10.0" />
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+<meta name="generator" content="pdoc3 0.11.6">
 <title>selenium_helper API documentation</title>
-<meta name="description" content="" />
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
-<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => {
+hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
+hljs.highlightAll();
+/* Collapse source docstrings */
+setTimeout(() => {
+[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
+.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
+.forEach(el => {
+let d = document.createElement('details');
+d.classList.add('hljs-string');
+d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
+el.replaceWith(d);
+});
+}, 100);
+})</script>
 </head>
 <body>
 <main>
@@ -22,274 +36,6 @@
 <h1 class="title">Module <code>selenium_helper</code></h1>
 </header>
 <section id="section-intro">
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python"># imports ------------------
-import time
-import logging
-import gc
-from selenium import webdriver
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.firefox import service as fs
-from selenium.common.exceptions import TimeoutException
-
-# Functions ------------------
-
-# Private Functions ------------------
-
-# Class ------------------
-
-
-class SeleniumBrowser:
-    &#34;&#34;&#34;
-    This is a module to support to use a selenium with several functions.
-    &#34;&#34;&#34;
-
-    def __init__(
-        self,
-        geckodriver_path: str,
-        headless: bool = True,
-        tor_access: bool = False,
-        tor_browser: bool = False,
-        browser_setting: dict = {&#34;browser_path&#34;: &#34;&#34;, &#34;browser_profile&#34;: &#34;&#34;},
-        addons: dict = {&#34;dir&#34;: &#34;&#34;, &#34;apps&#34;: []},
-        proxy: dict = {&#34;ip&#34;: &#34;&#34;, &#34;port&#34;: 3128},
-        set_size: bool = False,
-    ) -&gt; None:
-        &#34;&#34;&#34;
-        Class function for selenium browser
-        Args:
-            geckodriver_path: geckodriver&#39;s path
-            browser_path: browser&#39;s path, such as, Firefox or Tor
-            headless: Use headless mode (bool), default = True
-            tor_access: Use Tor (bool), default = False
-            tor_browser: Use Tor browser (bool), default = False
-            browser_setting: Browser setting (dict), default = {&#34;browser_path&#34;: &#34;&#34;, &#34;browser_profile&#34;: &#34;&#34;}
-            addons: Use installed addons (dict), default = {&#34;dir&#34;: &#34;&#34;, &#34;apps&#34;: []}
-            proxy: Use proxy server (dict), default = {&#34;ip&#34;: &#34;&#34;, &#34;port&#34;: &#34;&#34;}
-            set_size: set windows size as (900, 500) (bool), default = false
-        Returns:
-            browser: self.browser
-        &#34;&#34;&#34;
-        # input parameters
-        self.geckodriver_path = geckodriver_path
-        self.headless = headless
-        self.tor_access = tor_access
-        self.tor_browser = tor_browser
-        self.browser_setting = browser_setting
-        self.addons = addons
-        self.proxy = proxy
-        self.set_size = set_size
-        # initial check
-        init_ok = self._init_check()
-        if not init_ok:
-            raise NotCorrectValueException
-        # Activate headless mode of Firefox
-        options = webdriver.FirefoxOptions()
-        if headless:
-            options.add_argument(&#34;--headless&#34;)
-        # Profile should be set with options from Selenium4
-        options.set_preference(&#34;profile&#34;, browser_setting[&#34;browser_profile&#34;])
-        # Use Service for executable_path from Selenium4
-        firefox_service = fs.Service(executable_path=geckodriver_path)
-
-        if tor_access and tor_browser:
-            &#34;&#34;&#34;
-            Use tor network with tor browser.
-
-            [Caution] As of now, my browser doesn&#39;t connect to tor network automatically.
-            You need to connect to the tor network manually.
-            &#34;&#34;&#34;
-            proxyHost = &#34;127.0.0.1&#34;
-            proxyPort = 9150
-
-            options.binary_location = browser_setting[&#34;browser_path&#34;]
-            options.set_preference(&#34;network.proxy.type&#34;, 1)
-            options.set_preference(&#34;network.proxy.socks&#34;, proxyHost)  # SOCKS PROXY
-            options.set_preference(&#34;network.proxy.socks_port&#34;, proxyPort)
-            options.set_preference(&#34;network.proxy.socks_remote_dns&#34;, False)
-
-        elif tor_access:
-            &#34;&#34;&#34;
-            Use tor network with Firefox.
-
-            [Caution] You need to connect to the tor network manually,
-            such as, tor browser, and it provides proxy access with localhost and port 9150.
-            &#34;&#34;&#34;
-            proxyHost = &#34;127.0.0.1&#34;
-            proxyPort = 9150
-            options.binary_location = browser_setting[&#34;browser_path&#34;]
-            options.set_preference(&#34;network.proxy.type&#34;, 1)
-            options.set_preference(&#34;network.proxy.socks&#34;, proxyHost)  # SOCKS PROXY
-            options.set_preference(&#34;network.proxy.socks_port&#34;, proxyPort)
-
-        elif len(proxy[&#34;ip&#34;]) &gt; 0 and len(str(proxy[&#34;port&#34;])) &gt; 0:
-            # Proxy access with specified ip and port.
-            proxyHost = proxy[&#34;ip&#34;]
-            proxyPort = proxy[&#34;port&#34;]
-            options.binary_location = browser_setting[&#34;browser_path&#34;]
-            options.set_preference(&#34;network.proxy.type&#34;, 1)
-            options.set_preference(&#34;network.proxy.http&#34;, proxyHost)
-            options.set_preference(&#34;network.proxy.http_port&#34;, proxyPort)
-            options.set_preference(&#34;network.proxy.ssl&#34;, proxyHost)  # SSL PROXY
-            options.set_preference(&#34;network.proxy.ssl_port&#34;, proxyPort)
-
-        else:
-            # Normal access with selenium.
-            # get browser for selenium
-            options.binary_location = browser_setting[&#34;browser_path&#34;]
-
-        self.browser = webdriver.Firefox(service=firefox_service, options=options)
-
-        if len(addons[&#34;dir&#34;]) &gt; 0 and len(addons[&#34;apps&#34;]) &gt; 0:
-            # Use addons
-            extensions_dir = addons[&#34;dir&#34;]
-            extensions = addons[&#34;apps&#34;]
-            for extension in extensions:
-                self.browser.install_addon(extensions_dir + extension, temporary=True)
-
-        self.browser.implicitly_wait(10)  # set implicit time until a timeout (sec)
-
-        # Close other tabs.
-        time.sleep(1)
-        self.close_other_tabs()
-
-        if set_size:
-            # set position and size.
-            self.browser.set_window_position(0, 0)
-            self.browser.set_window_size(900, 500)
-
-        # delete parameters
-        del self.geckodriver_path
-        del self.headless
-        del self.tor_access
-        del self.tor_browser
-        del self.browser_setting
-        del self.addons
-        del self.proxy
-        del self.set_size
-
-    # Class Public Fuctions -------
-
-    def close_other_tabs(self) -&gt; None:
-        &#34;&#34;&#34;
-        Close other tabs
-        Args:
-            None
-        Returns:
-            None
-        &#34;&#34;&#34;
-        if len(self.browser.window_handles) &gt; 1:
-            for tabs in reversed(self.browser.window_handles):
-                if tabs == self.browser.window_handles[0]:
-                    self.browser.switch_to.window(tabs)
-                else:
-                    self.browser.switch_to.window(tabs)
-                    self.browser.close()
-
-    def check_gip(self) -&gt; str:
-        &#34;&#34;&#34;
-        Get current global IP
-        Args:
-            None
-        Returns:
-            gip: global IP (str)
-        &#34;&#34;&#34;
-        try:
-            self.browser.get(&#34;http://checkip.amazonaws.com&#34;)
-            WebDriverWait(self.browser, 10).until(
-                EC.presence_of_element_located((By.TAG_NAME, &#34;pre&#34;))
-            )
-        except Exception:
-            logging.info(&#34;Timeout to check IP&#34;)
-            return &#34;&#34;
-
-        gip = self.browser.find_element(By.TAG_NAME, &#34;pre&#34;).text
-        logging.info(f&#34;Global ip: {gip}&#34;)
-        return gip
-
-    def recur_selenium_get(self, url: str) -&gt; None:
-        &#34;&#34;&#34;
-        Access web page recursively.
-        Args:
-            url: web page url (str)
-        Returns:
-            None
-        &#34;&#34;&#34;
-        try:
-            self.browser.get(url)
-        except TimeoutException as e:
-            logging.error(f&#34;Timeout Error to access {url}. Retry &#34;, e)
-            self.recur_selenium_get(url)
-
-    def recur_scroll_down(self, speed: int, start_height: int = 1) -&gt; None:
-        &#34;&#34;&#34;
-        Scroll down recursively until bottom of the page.
-        Args:
-            speed: it should be tuned, based on the bandwidth of the internet.
-            start_height: start height value. it&#39;s 1 at the beginning.
-        Returns:
-            None
-        &#34;&#34;&#34;
-        # get page height
-        height = self.browser.execute_script(&#34;return document.body.scrollHeight&#34;)
-
-        # scroll down slowly with loop
-        for i in range(start_height, height, speed):
-            self.browser.execute_script(&#34;window.scrollTo(0, &#34; + str(i) + &#34;);&#34;)
-
-        # In case the rest of the page is dynamically loaded, execute this function recursively.
-        new_height = self.browser.execute_script(&#34;return document.body.scrollHeight&#34;)
-        if new_height - height &gt; 0:
-            self.recur_scroll_down(speed, height)
-        else:
-            return
-
-    def close_selenium(self) -&gt; None:
-        &#34;&#34;&#34;
-        Close browser.
-        Args:
-            None
-        Returns:
-            None
-        &#34;&#34;&#34;
-        self.browser.quit()
-        time.sleep(1)
-        del self.browser
-        gc.collect()
-
-    # Class Private Fuctions -------
-
-    def _init_check(self) -&gt; bool:
-        &#34;&#34;&#34;
-        Check parameters at the initialization.
-        Args:
-            None
-        Returns:
-            init_check_result: True or False
-        &#34;&#34;&#34;
-        if (
-            len(self.geckodriver_path) == 0
-            or len(self.browser_setting[&#34;browser_path&#34;]) == 0
-            or len(self.browser_setting[&#34;browser_profile&#34;]) == 0
-        ):
-            # geckodriver_path and browser setting are mandatory.
-            init_ok = False
-        elif (len(self.addons[&#34;dir&#34;]) == 0) ^ (len(self.addons[&#34;apps&#34;]) == 0):
-            # addons needs [&#34;apps&#34;] and [&#34;dir&#34;].
-            init_ok = False
-        else:
-            init_ok = True
-        return init_ok
-
-
-class NotCorrectValueException(Exception):
-    pass</code></pre>
-</details>
 </section>
 <section>
 </section>
@@ -305,7 +51,6 @@ class NotCorrectValueException(Exception):
 <span>(</span><span>*args, **kwargs)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -313,6 +58,7 @@ class NotCorrectValueException(Exception):
 <pre><code class="python">class NotCorrectValueException(Exception):
     pass</code></pre>
 </details>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>builtins.Exception</li>
@@ -321,37 +67,9 @@ class NotCorrectValueException(Exception):
 </dd>
 <dt id="selenium_helper.SeleniumBrowser"><code class="flex name class">
 <span>class <span class="ident">SeleniumBrowser</span></span>
-<span>(</span><span>geckodriver_path: str, headless: bool = True, tor_access: bool = False, tor_browser: bool = False, browser_setting: dict = {'browser_path': '', 'browser_profile': ''}, addons: dict = {'dir': '', 'apps': []}, proxy: dict = {'ip': '', 'port': 3128}, set_size: bool = False)</span>
+<span>(</span><span>geckodriver_path: str,<br>headless: bool = True,<br>tor_access: bool = False,<br>tor_browser: bool = False,<br>browser_setting: dict = {'browser_path': '', 'browser_profile': ''},<br>addons: dict = {'dir': '', 'apps': []},<br>proxy: dict = {'ip': '', 'port': 3128},<br>set_size: bool = False,<br>private_mode: bool = False,<br>session_cookies_only: bool = False)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>This is a module to support to use a selenium with several functions.</p>
-<p>Class function for selenium browser</p>
-<h2 id="args">Args</h2>
-<dl>
-<dt><strong><code>geckodriver_path</code></strong></dt>
-<dd>geckodriver's path</dd>
-<dt><strong><code>browser_path</code></strong></dt>
-<dd>browser's path, such as, Firefox or Tor</dd>
-<dt><strong><code>headless</code></strong></dt>
-<dd>Use headless mode (bool), default = True</dd>
-<dt><strong><code>tor_access</code></strong></dt>
-<dd>Use Tor (bool), default = False</dd>
-<dt><strong><code>tor_browser</code></strong></dt>
-<dd>Use Tor browser (bool), default = False</dd>
-<dt><strong><code>browser_setting</code></strong></dt>
-<dd>Browser setting (dict), default = {"browser_path": "", "browser_profile": ""}</dd>
-<dt><strong><code>addons</code></strong></dt>
-<dd>Use installed addons (dict), default = {"dir": "", "apps": []}</dd>
-<dt><strong><code>proxy</code></strong></dt>
-<dd>Use proxy server (dict), default = {"ip": "", "port": ""}</dd>
-<dt><strong><code>set_size</code></strong></dt>
-<dd>set windows size as (900, 500) (bool), default = false</dd>
-</dl>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><code>browser</code></dt>
-<dd>self.browser</dd>
-</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -371,6 +89,8 @@ class NotCorrectValueException(Exception):
         addons: dict = {&#34;dir&#34;: &#34;&#34;, &#34;apps&#34;: []},
         proxy: dict = {&#34;ip&#34;: &#34;&#34;, &#34;port&#34;: 3128},
         set_size: bool = False,
+        private_mode: bool = False,
+        session_cookies_only: bool = False,
     ) -&gt; None:
         &#34;&#34;&#34;
         Class function for selenium browser
@@ -384,6 +104,8 @@ class NotCorrectValueException(Exception):
             addons: Use installed addons (dict), default = {&#34;dir&#34;: &#34;&#34;, &#34;apps&#34;: []}
             proxy: Use proxy server (dict), default = {&#34;ip&#34;: &#34;&#34;, &#34;port&#34;: &#34;&#34;}
             set_size: set windows size as (900, 500) (bool), default = false
+            private_mode: start browser in private browsing so nothing is persisted to disk (bool), default = False
+            session_cookies_only: discard all cookies when the browser closes (bool), default = False
         Returns:
             browser: self.browser
         &#34;&#34;&#34;
@@ -396,6 +118,8 @@ class NotCorrectValueException(Exception):
         self.addons = addons
         self.proxy = proxy
         self.set_size = set_size
+        self.private_mode = private_mode
+        self.session_cookies_only = session_cookies_only
         # initial check
         init_ok = self._init_check()
         if not init_ok:
@@ -404,6 +128,12 @@ class NotCorrectValueException(Exception):
         options = webdriver.FirefoxOptions()
         if headless:
             options.add_argument(&#34;--headless&#34;)
+        if private_mode:
+            # Method 3: private browsing, nothing (incl. cookies) is written to disk.
+            options.set_preference(&#34;browser.privatebrowsing.autostart&#34;, True)
+        if session_cookies_only:
+            # Method 2: keep cookies for the session only, discard them on browser close.
+            options.set_preference(&#34;network.cookie.lifetimePolicy&#34;, 2)
         # Profile should be set with options from Selenium4
         options.set_preference(&#34;profile&#34;, browser_setting[&#34;browser_profile&#34;])
         # Use Service for executable_path from Selenium4
@@ -484,8 +214,20 @@ class NotCorrectValueException(Exception):
         del self.addons
         del self.proxy
         del self.set_size
+        del self.private_mode
+        del self.session_cookies_only
 
     # Class Public Fuctions -------
+
+    def delete_all_cookies(self) -&gt; None:
+        &#34;&#34;&#34;
+        Delete all cookies in the current browser session (Method 1).
+        Args:
+            None
+        Returns:
+            None
+        &#34;&#34;&#34;
+        self.browser.delete_all_cookies()
 
     def close_other_tabs(self) -&gt; None:
         &#34;&#34;&#34;
@@ -598,20 +340,44 @@ class NotCorrectValueException(Exception):
             init_ok = True
         return init_ok</code></pre>
 </details>
+<div class="desc"><p>This is a module to support to use a selenium with several functions.</p>
+<p>Class function for selenium browser</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>geckodriver_path</code></strong></dt>
+<dd>geckodriver's path</dd>
+<dt><strong><code>browser_path</code></strong></dt>
+<dd>browser's path, such as, Firefox or Tor</dd>
+<dt><strong><code>headless</code></strong></dt>
+<dd>Use headless mode (bool), default = True</dd>
+<dt><strong><code>tor_access</code></strong></dt>
+<dd>Use Tor (bool), default = False</dd>
+<dt><strong><code>tor_browser</code></strong></dt>
+<dd>Use Tor browser (bool), default = False</dd>
+<dt><strong><code>browser_setting</code></strong></dt>
+<dd>Browser setting (dict), default = {"browser_path": "", "browser_profile": ""}</dd>
+<dt><strong><code>addons</code></strong></dt>
+<dd>Use installed addons (dict), default = {"dir": "", "apps": []}</dd>
+<dt><strong><code>proxy</code></strong></dt>
+<dd>Use proxy server (dict), default = {"ip": "", "port": ""}</dd>
+<dt><strong><code>set_size</code></strong></dt>
+<dd>set windows size as (900, 500) (bool), default = false</dd>
+<dt><strong><code>private_mode</code></strong></dt>
+<dd>start browser in private browsing so nothing is persisted to disk (bool), default = False</dd>
+<dt><strong><code>session_cookies_only</code></strong></dt>
+<dd>discard all cookies when the browser closes (bool), default = False</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>browser</code></dt>
+<dd>self.browser</dd>
+</dl></div>
 <h3>Methods</h3>
 <dl>
 <dt id="selenium_helper.SeleniumBrowser.check_gip"><code class="name flex">
 <span>def <span class="ident">check_gip</span></span>(<span>self) ‑> str</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Get current global IP</p>
-<h2 id="args">Args</h2>
-<p>None</p>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><code>gip</code></dt>
-<dd>global IP (str)</dd>
-</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -637,16 +403,19 @@ class NotCorrectValueException(Exception):
     logging.info(f&#34;Global ip: {gip}&#34;)
     return gip</code></pre>
 </details>
+<div class="desc"><p>Get current global IP</p>
+<h2 id="args">Args</h2>
+<p>None</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>gip</code></dt>
+<dd>global IP (str)</dd>
+</dl></div>
 </dd>
 <dt id="selenium_helper.SeleniumBrowser.close_other_tabs"><code class="name flex">
 <span>def <span class="ident">close_other_tabs</span></span>(<span>self) ‑> None</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Close other tabs</p>
-<h2 id="args">Args</h2>
-<p>None</p>
-<h2 id="returns">Returns</h2>
-<p>None</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -667,16 +436,16 @@ class NotCorrectValueException(Exception):
                 self.browser.switch_to.window(tabs)
                 self.browser.close()</code></pre>
 </details>
+<div class="desc"><p>Close other tabs</p>
+<h2 id="args">Args</h2>
+<p>None</p>
+<h2 id="returns">Returns</h2>
+<p>None</p></div>
 </dd>
 <dt id="selenium_helper.SeleniumBrowser.close_selenium"><code class="name flex">
 <span>def <span class="ident">close_selenium</span></span>(<span>self) ‑> None</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Close browser.</p>
-<h2 id="args">Args</h2>
-<p>None</p>
-<h2 id="returns">Returns</h2>
-<p>None</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -694,21 +463,40 @@ class NotCorrectValueException(Exception):
     del self.browser
     gc.collect()</code></pre>
 </details>
+<div class="desc"><p>Close browser.</p>
+<h2 id="args">Args</h2>
+<p>None</p>
+<h2 id="returns">Returns</h2>
+<p>None</p></div>
+</dd>
+<dt id="selenium_helper.SeleniumBrowser.delete_all_cookies"><code class="name flex">
+<span>def <span class="ident">delete_all_cookies</span></span>(<span>self) ‑> None</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def delete_all_cookies(self) -&gt; None:
+    &#34;&#34;&#34;
+    Delete all cookies in the current browser session (Method 1).
+    Args:
+        None
+    Returns:
+        None
+    &#34;&#34;&#34;
+    self.browser.delete_all_cookies()</code></pre>
+</details>
+<div class="desc"><p>Delete all cookies in the current browser session (Method 1).</p>
+<h2 id="args">Args</h2>
+<p>None</p>
+<h2 id="returns">Returns</h2>
+<p>None</p></div>
 </dd>
 <dt id="selenium_helper.SeleniumBrowser.recur_scroll_down"><code class="name flex">
 <span>def <span class="ident">recur_scroll_down</span></span>(<span>self, speed: int, start_height: int = 1) ‑> None</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Scroll down recursively until bottom of the page.</p>
-<h2 id="args">Args</h2>
-<dl>
-<dt><strong><code>speed</code></strong></dt>
-<dd>it should be tuned, based on the bandwidth of the internet.</dd>
-<dt><strong><code>start_height</code></strong></dt>
-<dd>start height value. it's 1 at the beginning.</dd>
-</dl>
-<h2 id="returns">Returns</h2>
-<p>None</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -736,19 +524,21 @@ class NotCorrectValueException(Exception):
     else:
         return</code></pre>
 </details>
+<div class="desc"><p>Scroll down recursively until bottom of the page.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>speed</code></strong></dt>
+<dd>it should be tuned, based on the bandwidth of the internet.</dd>
+<dt><strong><code>start_height</code></strong></dt>
+<dd>start height value. it's 1 at the beginning.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>None</p></div>
 </dd>
 <dt id="selenium_helper.SeleniumBrowser.recur_selenium_get"><code class="name flex">
 <span>def <span class="ident">recur_selenium_get</span></span>(<span>self, url: str) ‑> None</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Access web page recursively.</p>
-<h2 id="args">Args</h2>
-<dl>
-<dt><strong><code>url</code></strong></dt>
-<dd>web page url (str)</dd>
-</dl>
-<h2 id="returns">Returns</h2>
-<p>None</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -767,6 +557,14 @@ class NotCorrectValueException(Exception):
         logging.error(f&#34;Timeout Error to access {url}. Retry &#34;, e)
         self.recur_selenium_get(url)</code></pre>
 </details>
+<div class="desc"><p>Access web page recursively.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>url</code></strong></dt>
+<dd>web page url (str)</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>None</p></div>
 </dd>
 </dl>
 </dd>
@@ -774,7 +572,6 @@ class NotCorrectValueException(Exception):
 </section>
 </article>
 <nav id="sidebar">
-<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -786,10 +583,11 @@ class NotCorrectValueException(Exception):
 </li>
 <li>
 <h4><code><a title="selenium_helper.SeleniumBrowser" href="#selenium_helper.SeleniumBrowser">SeleniumBrowser</a></code></h4>
-<ul class="">
+<ul class="two-column">
 <li><code><a title="selenium_helper.SeleniumBrowser.check_gip" href="#selenium_helper.SeleniumBrowser.check_gip">check_gip</a></code></li>
 <li><code><a title="selenium_helper.SeleniumBrowser.close_other_tabs" href="#selenium_helper.SeleniumBrowser.close_other_tabs">close_other_tabs</a></code></li>
 <li><code><a title="selenium_helper.SeleniumBrowser.close_selenium" href="#selenium_helper.SeleniumBrowser.close_selenium">close_selenium</a></code></li>
+<li><code><a title="selenium_helper.SeleniumBrowser.delete_all_cookies" href="#selenium_helper.SeleniumBrowser.delete_all_cookies">delete_all_cookies</a></code></li>
 <li><code><a title="selenium_helper.SeleniumBrowser.recur_scroll_down" href="#selenium_helper.SeleniumBrowser.recur_scroll_down">recur_scroll_down</a></code></li>
 <li><code><a title="selenium_helper.SeleniumBrowser.recur_selenium_get" href="#selenium_helper.SeleniumBrowser.recur_selenium_get">recur_selenium_get</a></code></li>
 </ul>
@@ -800,7 +598,7 @@ class NotCorrectValueException(Exception):
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
 </footer>
 </body>
 </html>

--- a/selenium_helper/selenium_helper.py
+++ b/selenium_helper/selenium_helper.py
@@ -60,8 +60,6 @@ class SeleniumBrowser:
         self.addons = addons
         self.proxy = proxy
         self.set_size = set_size
-        self.private_mode = private_mode
-        self.session_cookies_only = session_cookies_only
         # initial check
         init_ok = self._init_check()
         if not init_ok:
@@ -156,8 +154,6 @@ class SeleniumBrowser:
         del self.addons
         del self.proxy
         del self.set_size
-        del self.private_mode
-        del self.session_cookies_only
 
     # Class Public Fuctions -------
 

--- a/selenium_helper/selenium_helper.py
+++ b/selenium_helper/selenium_helper.py
@@ -31,6 +31,8 @@ class SeleniumBrowser:
         addons: dict = {"dir": "", "apps": []},
         proxy: dict = {"ip": "", "port": 3128},
         set_size: bool = False,
+        private_mode: bool = False,
+        session_cookies_only: bool = False,
     ) -> None:
         """
         Class function for selenium browser
@@ -44,6 +46,8 @@ class SeleniumBrowser:
             addons: Use installed addons (dict), default = {"dir": "", "apps": []}
             proxy: Use proxy server (dict), default = {"ip": "", "port": ""}
             set_size: set windows size as (900, 500) (bool), default = false
+            private_mode: start browser in private browsing so nothing is persisted to disk (bool), default = False
+            session_cookies_only: discard all cookies when the browser closes (bool), default = False
         Returns:
             browser: self.browser
         """
@@ -56,6 +60,8 @@ class SeleniumBrowser:
         self.addons = addons
         self.proxy = proxy
         self.set_size = set_size
+        self.private_mode = private_mode
+        self.session_cookies_only = session_cookies_only
         # initial check
         init_ok = self._init_check()
         if not init_ok:
@@ -64,6 +70,12 @@ class SeleniumBrowser:
         options = webdriver.FirefoxOptions()
         if headless:
             options.add_argument("--headless")
+        if private_mode:
+            # Method 3: private browsing, nothing (incl. cookies) is written to disk.
+            options.set_preference("browser.privatebrowsing.autostart", True)
+        if session_cookies_only:
+            # Method 2: keep cookies for the session only, discard them on browser close.
+            options.set_preference("network.cookie.lifetimePolicy", 2)
         # Profile should be set with options from Selenium4
         options.set_preference("profile", browser_setting["browser_profile"])
         # Use Service for executable_path from Selenium4
@@ -144,8 +156,20 @@ class SeleniumBrowser:
         del self.addons
         del self.proxy
         del self.set_size
+        del self.private_mode
+        del self.session_cookies_only
 
     # Class Public Fuctions -------
+
+    def delete_all_cookies(self) -> None:
+        """
+        Delete all cookies in the current browser session (Method 1).
+        Args:
+            None
+        Returns:
+            None
+        """
+        self.browser.delete_all_cookies()
 
     def close_other_tabs(self) -> None:
         """


### PR DESCRIPTION
This pull request adds new privacy-related features and a utility method to the `SeleniumHelper` class in `selenium_helper.py`. The main changes introduce options for starting the browser in private mode and for discarding cookies after the session, as well as a method to delete all cookies during a session.

**New privacy options:**

* Added `private_mode` and `session_cookies_only` parameters to the class initializer, allowing users to start the browser in private browsing mode and/or to discard all cookies when the browser closes. These are exposed as arguments, set as instance attributes, and documented in the docstring. [[1]](diffhunk://#diff-454329d1de248cdca18ae1d19b31f34fa8249745c6e8b8d2e17daaefad87f4fdR34-R35) [[2]](diffhunk://#diff-454329d1de248cdca18ae1d19b31f34fa8249745c6e8b8d2e17daaefad87f4fdR49-R50) [[3]](diffhunk://#diff-454329d1de248cdca18ae1d19b31f34fa8249745c6e8b8d2e17daaefad87f4fdR63-R64)
* Updated Firefox options to enable private browsing (`browser.privatebrowsing.autostart`) and session-only cookies (`network.cookie.lifetimePolicy`) when the corresponding parameters are set.

**New utility method:**

* Added a `delete_all_cookies` method to allow deletion of all cookies in the current browser session.

**Cleanup:**

* Ensured the new instance attributes (`private_mode`, `session_cookies_only`) are deleted in the class destructor for proper resource management.