### PR TITLE
Fix/tor access vul

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ brsr = SeleniumBrowser(geckodriver_path = geckodriver_path, browser_setting = {"
 * geckodriver_path: You need to specify geckodriver path. (You need to install geckodriver before use this module.)
 * headless: Use headless mode (bool), default = True
 * tor_access: Use Tor (bool), default = False
+  * When enabled, DNS is resolved through the SOCKS5 proxy (`network.proxy.socks_remote_dns=True`) and WebRTC is disabled (`media.peerconnection.enabled=False`) to prevent DNS and IP (WebRTC) leaks.
 * tor_browser: Use Tor browser (bool), default = False
+  * The same DNS/WebRTC leak protections as `tor_access` are applied.
 * browser_setting: Browser setting (dict), default = {"browser_path": "", "browser_profile": ""}
 * addons: Use installed addons (dict), default = {"dir": "", "apps": []}
 * proxy: Use proxy server (dict), default = {"ip": "", "port": ""}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ brsr = SeleniumBrowser(geckodriver_path = geckodriver_path, browser_setting = {"
 * tor_access: Use Tor (bool), default = False
   * When enabled, DNS is resolved through the SOCKS5 proxy (`network.proxy.socks_remote_dns=True`) and WebRTC is disabled (`media.peerconnection.enabled=False`) to prevent DNS and IP (WebRTC) leaks.
 * tor_browser: Use Tor browser (bool), default = False
-  * The same DNS/WebRTC leak protections as `tor_access` are applied.
+  * Only effective together with `tor_access=True`. The DNS/WebRTC leak protections above are applied whenever `tor_access=True` (with or without `tor_browser`); `tor_browser` alone has no effect.
 * browser_setting: Browser setting (dict), default = {"browser_path": "", "browser_profile": ""}
 * addons: Use installed addons (dict), default = {"dir": "", "apps": []}
 * proxy: Use proxy server (dict), default = {"ip": "", "port": ""}

--- a/docs/index.html
+++ b/docs/index.html
@@ -365,9 +365,9 @@ When True, DNS is resolved through the SOCKS5 proxy
 (media.peerconnection.enabled=False) to prevent DNS and IP leaks.</dd>
 <dt><strong><code>tor_browser</code></strong></dt>
 <dd>Use Tor browser (bool), default = False
-Only effective together with tor_access=True. The DNS/WebRTC leak protections
-above are applied whenever tor_access=True (with or without tor_browser);
-tor_browser alone has no effect.</dd>
+Only effective together with tor_access=True. The DNS/WebRTC
+leak protections above are applied whenever tor_access=True
+(with or without tor_browser); tor_browser alone has no effect.</dd>
 <dt><strong><code>browser_setting</code></strong></dt>
 <dd>Browser setting (dict), default = {"browser_path": "", "browser_profile": ""}</dd>
 <dt><strong><code>addons</code></strong></dt>

--- a/docs/index.html
+++ b/docs/index.html
@@ -99,7 +99,11 @@ el.replaceWith(d);
             browser_path: browser&#39;s path, such as, Firefox or Tor
             headless: Use headless mode (bool), default = True
             tor_access: Use Tor (bool), default = False
+                When True, DNS is resolved through the SOCKS5 proxy
+                (network.proxy.socks_remote_dns=True) and WebRTC is disabled
+                (media.peerconnection.enabled=False) to prevent DNS and IP leaks.
             tor_browser: Use Tor browser (bool), default = False
+                The same DNS/WebRTC leak protections as tor_access are applied.
             browser_setting: Browser setting (dict), default = {&#34;browser_path&#34;: &#34;&#34;, &#34;browser_profile&#34;: &#34;&#34;}
             addons: Use installed addons (dict), default = {&#34;dir&#34;: &#34;&#34;, &#34;apps&#34;: []}
             proxy: Use proxy server (dict), default = {&#34;ip&#34;: &#34;&#34;, &#34;port&#34;: &#34;&#34;}
@@ -151,7 +155,10 @@ el.replaceWith(d);
             options.set_preference(&#34;network.proxy.type&#34;, 1)
             options.set_preference(&#34;network.proxy.socks&#34;, proxyHost)  # SOCKS PROXY
             options.set_preference(&#34;network.proxy.socks_port&#34;, proxyPort)
-            options.set_preference(&#34;network.proxy.socks_remote_dns&#34;, False)
+            # Resolve DNS through the SOCKS5 proxy (Tor) to avoid DNS leaks.
+            options.set_preference(&#34;network.proxy.socks_remote_dns&#34;, True)
+            # Disable WebRTC to avoid real IP leaks via STUN bypassing the proxy.
+            options.set_preference(&#34;media.peerconnection.enabled&#34;, False)
 
         elif tor_access:
             &#34;&#34;&#34;
@@ -166,6 +173,10 @@ el.replaceWith(d);
             options.set_preference(&#34;network.proxy.type&#34;, 1)
             options.set_preference(&#34;network.proxy.socks&#34;, proxyHost)  # SOCKS PROXY
             options.set_preference(&#34;network.proxy.socks_port&#34;, proxyPort)
+            # Resolve DNS through the SOCKS5 proxy (Tor) to avoid DNS leaks.
+            options.set_preference(&#34;network.proxy.socks_remote_dns&#34;, True)
+            # Disable WebRTC to avoid real IP leaks via STUN bypassing the proxy.
+            options.set_preference(&#34;media.peerconnection.enabled&#34;, False)
 
         elif len(proxy[&#34;ip&#34;]) &gt; 0 and len(str(proxy[&#34;port&#34;])) &gt; 0:
             # Proxy access with specified ip and port.
@@ -346,9 +357,13 @@ el.replaceWith(d);
 <dt><strong><code>headless</code></strong></dt>
 <dd>Use headless mode (bool), default = True</dd>
 <dt><strong><code>tor_access</code></strong></dt>
-<dd>Use Tor (bool), default = False</dd>
+<dd>Use Tor (bool), default = False
+When True, DNS is resolved through the SOCKS5 proxy
+(network.proxy.socks_remote_dns=True) and WebRTC is disabled
+(media.peerconnection.enabled=False) to prevent DNS and IP leaks.</dd>
 <dt><strong><code>tor_browser</code></strong></dt>
-<dd>Use Tor browser (bool), default = False</dd>
+<dd>Use Tor browser (bool), default = False
+The same DNS/WebRTC leak protections as tor_access are applied.</dd>
 <dt><strong><code>browser_setting</code></strong></dt>
 <dd>Browser setting (dict), default = {"browser_path": "", "browser_profile": ""}</dd>
 <dt><strong><code>addons</code></strong></dt>

--- a/docs/index.html
+++ b/docs/index.html
@@ -103,7 +103,9 @@ el.replaceWith(d);
                 (network.proxy.socks_remote_dns=True) and WebRTC is disabled
                 (media.peerconnection.enabled=False) to prevent DNS and IP leaks.
             tor_browser: Use Tor browser (bool), default = False
-                The same DNS/WebRTC leak protections as tor_access are applied.
+                Only effective together with tor_access=True. The DNS/WebRTC
+                leak protections above are applied whenever tor_access=True
+                (with or without tor_browser); tor_browser alone has no effect.
             browser_setting: Browser setting (dict), default = {&#34;browser_path&#34;: &#34;&#34;, &#34;browser_profile&#34;: &#34;&#34;}
             addons: Use installed addons (dict), default = {&#34;dir&#34;: &#34;&#34;, &#34;apps&#34;: []}
             proxy: Use proxy server (dict), default = {&#34;ip&#34;: &#34;&#34;, &#34;port&#34;: &#34;&#34;}
@@ -363,7 +365,9 @@ When True, DNS is resolved through the SOCKS5 proxy
 (media.peerconnection.enabled=False) to prevent DNS and IP leaks.</dd>
 <dt><strong><code>tor_browser</code></strong></dt>
 <dd>Use Tor browser (bool), default = False
-The same DNS/WebRTC leak protections as tor_access are applied.</dd>
+Only effective together with tor_access=True. The DNS/WebRTC leak protections
+above are applied whenever tor_access=True (with or without tor_browser);
+tor_browser alone has no effect.</dd>
 <dt><strong><code>browser_setting</code></strong></dt>
 <dd>Browser setting (dict), default = {"browser_path": "", "browser_profile": ""}</dd>
 <dt><strong><code>addons</code></strong></dt>

--- a/selenium_helper/selenium_helper.py
+++ b/selenium_helper/selenium_helper.py
@@ -41,7 +41,11 @@ class SeleniumBrowser:
             browser_path: browser's path, such as, Firefox or Tor
             headless: Use headless mode (bool), default = True
             tor_access: Use Tor (bool), default = False
+                When True, DNS is resolved through the SOCKS5 proxy
+                (network.proxy.socks_remote_dns=True) and WebRTC is disabled
+                (media.peerconnection.enabled=False) to prevent DNS and IP leaks.
             tor_browser: Use Tor browser (bool), default = False
+                The same DNS/WebRTC leak protections as tor_access are applied.
             browser_setting: Browser setting (dict), default = {"browser_path": "", "browser_profile": ""}
             addons: Use installed addons (dict), default = {"dir": "", "apps": []}
             proxy: Use proxy server (dict), default = {"ip": "", "port": ""}
@@ -93,7 +97,10 @@ class SeleniumBrowser:
             options.set_preference("network.proxy.type", 1)
             options.set_preference("network.proxy.socks", proxyHost)  # SOCKS PROXY
             options.set_preference("network.proxy.socks_port", proxyPort)
-            options.set_preference("network.proxy.socks_remote_dns", False)
+            # Resolve DNS through the SOCKS5 proxy (Tor) to avoid DNS leaks.
+            options.set_preference("network.proxy.socks_remote_dns", True)
+            # Disable WebRTC to avoid real IP leaks via STUN bypassing the proxy.
+            options.set_preference("media.peerconnection.enabled", False)
 
         elif tor_access:
             """
@@ -108,6 +115,10 @@ class SeleniumBrowser:
             options.set_preference("network.proxy.type", 1)
             options.set_preference("network.proxy.socks", proxyHost)  # SOCKS PROXY
             options.set_preference("network.proxy.socks_port", proxyPort)
+            # Resolve DNS through the SOCKS5 proxy (Tor) to avoid DNS leaks.
+            options.set_preference("network.proxy.socks_remote_dns", True)
+            # Disable WebRTC to avoid real IP leaks via STUN bypassing the proxy.
+            options.set_preference("media.peerconnection.enabled", False)
 
         elif len(proxy["ip"]) > 0 and len(str(proxy["port"])) > 0:
             # Proxy access with specified ip and port.

--- a/selenium_helper/selenium_helper.py
+++ b/selenium_helper/selenium_helper.py
@@ -45,7 +45,9 @@ class SeleniumBrowser:
                 (network.proxy.socks_remote_dns=True) and WebRTC is disabled
                 (media.peerconnection.enabled=False) to prevent DNS and IP leaks.
             tor_browser: Use Tor browser (bool), default = False
-                The same DNS/WebRTC leak protections as tor_access are applied.
+                Only effective together with tor_access=True. The DNS/WebRTC
+                leak protections above are applied whenever tor_access=True
+                (with or without tor_browser); tor_browser alone has no effect.
             browser_setting: Browser setting (dict), default = {"browser_path": "", "browser_profile": ""}
             addons: Use installed addons (dict), default = {"dir": "", "apps": []}
             proxy: Use proxy server (dict), default = {"ip": "", "port": ""}

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup, find_packages
 
-setup(name="selenium_helper", version="1.2", packages=find_packages())
+setup(name="selenium_helper", version="1.3", packages=find_packages())


### PR DESCRIPTION
This pull request strengthens privacy protections for Tor and SOCKS5 proxy users in the Selenium helper by ensuring DNS and WebRTC leak prevention. It also updates documentation to clearly explain these improvements and bumps the package version to 1.3.

### Privacy and Security Enhancements
* Updated `selenium_helper/selenium_helper.py` to set `network.proxy.socks_remote_dns=True` and disable WebRTC (`media.peerconnection.enabled=False`) when using Tor or SOCKS5 proxies, preventing DNS and real IP leaks. [[1]](diffhunk://#diff-454329d1de248cdca18ae1d19b31f34fa8249745c6e8b8d2e17daaefad87f4fdL96-R103) [[2]](diffhunk://#diff-454329d1de248cdca18ae1d19b31f34fa8249745c6e8b8d2e17daaefad87f4fdR118-R121)
* Applied the same DNS and WebRTC leak protections to Tor Browser mode as with Tor proxy usage. [[1]](diffhunk://#diff-454329d1de248cdca18ae1d19b31f34fa8249745c6e8b8d2e17daaefad87f4fdL96-R103) [[2]](diffhunk://#diff-454329d1de248cdca18ae1d19b31f34fa8249745c6e8b8d2e17daaefad87f4fdR118-R121)

### Documentation Updates
* Improved parameter documentation and usage notes in `selenium_helper/selenium_helper.py`, `README.md`, and `docs/index.html` to describe the new privacy protections for `tor_access` and `tor_browser` options. [[1]](diffhunk://#diff-454329d1de248cdca18ae1d19b31f34fa8249745c6e8b8d2e17daaefad87f4fdR44-R48) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R29-R31) [[3]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeR102-R106) [[4]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL349-R366)
* Updated code examples and explanations in `docs/index.html` to reflect the new default settings for DNS and WebRTC leak prevention. [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL154-R161) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeR176-R179)

### Versioning
* Bumped the package version in `setup.py` from 1.2 to 1.3 to reflect these improvements.